### PR TITLE
fix: prevent REG_IER from being overwritten

### DIFF
--- a/src/ESP32SJA1000.cpp
+++ b/src/ESP32SJA1000.cpp
@@ -152,7 +152,7 @@ int ESP32SJA1000Class::begin(long baudRate)
   }
 
   modifyRegister(REG_BTR1, 0x80, 0x80); // SAM = 1
-  writeRegister(REG_IER, 0xff); // enable all interrupts
+  modifyRegister(REG_IER, 0xef, 0xef); // enable all interrupts
 
   // set filter to allow anything
   writeRegister(REG_ACRn(0), 0x00);


### PR DESCRIPTION
I think REG_IER is overwrite 0xFF by writeRegister